### PR TITLE
Fix MONOGO_DB_URL with st.scerets

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,12 +1,18 @@
-import pymongo
-import pandas as pd
-import json
 import os
 from dataclasses import dataclass
+
+import pymongo
+import streamlit as st
+
 
 @dataclass
 class EnvironmentVariable:
     mongo_db_url = os.getenv("MONGO_DB_URL")
+
+    def __post_init__(self):
+        if self.mongo_db_url is None:
+            self.mongo_db_url = st.secrets['MONGO_DB_URL']
+
 
 env_var = EnvironmentVariable()
 mongo_client = pymongo.MongoClient(env_var.mongo_db_url)


### PR DESCRIPTION
Streamlit app doesn't ise `.env` file instead it uses `secrets.toml` to get environment variable. So I fix this in 68c69403c7d097d01f30f51f6afdc2f086a7a17f